### PR TITLE
Update CubeCellTTNMapper_decoder.js

### DIFF
--- a/CubeCellTTNMapper_decoder.js
+++ b/CubeCellTTNMapper_decoder.js
@@ -1,27 +1,27 @@
 function Decoder(bytes, port) {
-  // Decode an uplink message from a buffer
-  // (array) of bytes to an object of fields.
   var decoded = {};
-  // if (port === 1) decoded.led = bytes[0];
-  decoded.latitude = ((bytes[0]<<16)>>>0) + ((bytes[1]<<8)>>>0) + bytes[2];
-  decoded.latitude = (decoded.latitude / 16777215.0 * 180) - 90;
-  decoded.longitude = ((bytes[3]<<16)>>>0) + ((bytes[4]<<8)>>>0) + bytes[5];
-  decoded.longitude = (decoded.longitude / 16777215.0 * 360) - 180;
-  var altValue = ((bytes[6]<<8)>>>0) + bytes[7];
-  var sign = bytes[6] & (1 << 7);
-  if(sign)
-  {
-    decoded.altitude = 0xFFFF0000 | altValue;
+
+  // Location reports are sent on appPort = 2
+  if (port === 2) {
+    decoded.latitude = ((bytes[0]<<16)>>>0) + ((bytes[1]<<8)>>>0) + bytes[2];
+    decoded.latitude = (decoded.latitude / 16777215.0 * 180) - 90;
+    decoded.longitude = ((bytes[3]<<16)>>>0) + ((bytes[4]<<8)>>>0) + bytes[5];
+    decoded.longitude = (decoded.longitude / 16777215.0 * 360) - 180;
+    var altValue = ((bytes[6]<<8)>>>0) + bytes[7];
+    var sign = bytes[6] & (1 << 7);
+    if(sign)
+    {
+      decoded.altitude = 0xFFFF0000 | altValue;
+    }
+    else
+    {
+      decoded.altitude = altValue;
+    }
+    decoded.hdop = bytes[8] / 10.0;
+    decoded.satellites = bytes[9] & 0x7F;
+    if(bytes[9] & (1 << 7))
+      decoded.poi = true;
+    decoded.heading = -1;
   }
-  else
-  {
-    decoded.altitude = altValue;
-  }
-  decoded.hdop = bytes[8] / 10.0;
-  decoded.satellites = bytes[9] & 0x7F;
-  if(bytes[9] & (1 << 7))
-    decoded.poi = true;
-  decoded.heading = -1;
   return decoded;
 }
-


### PR DESCRIPTION
Only decode port 2 frames as location. This may help prevent invalid locations - issue #2.

Port is defined in https://github.com/Bwooce/CubeCellTTNMapper/blob/24dd19b7d7e52685b95d0429086c87aaf57bb467/CubeCellTTNMapper.ino#L65